### PR TITLE
[FIX] Moved walk-sync, mkdirp & quick-temp to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
     "zetzer": "^2.0.0",
     "underscore": "^1.6.0",
     "promise-map-series": "0.2",
-    "broccoli-dep-filter": "^0.3.0"
+    "broccoli-dep-filter": "^0.3.0",
+    "walk-sync": "0.1",
+    "mkdirp": "0.3",
+    "quick-temp": "0.1"
   },
   "devDependencies": {
     "broccoli-cli": "*",
     "broccoli": "0.13",
-    "walk-sync": "0.1",
-    "mkdirp": "0.3",
-    "quick-temp": "0.1",
     "grunt-zetzer": "^2.0.0"
   },
   "keywords": [


### PR DESCRIPTION
After installing the package on a project, I realised that 3 packages were not being installed after running `$ npm install` : `walk-sync, mkdirp & quick-temp`

The errors were :

``` shell
$ Error: Cannot find module 'walk-sync'
$ Error: Cannot find module 'mkdirp'
$ Error: Cannot find module 'quick-temp'
```

I just moved those 3 to the dependencies object in the package.json.
