### PR TITLE
[FIX] Fixed issue when a template had the same name that a directory

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,11 @@
+{
+  "node": true,
+  "esnext": true,
+  "bitwise": true,
+  "curly": true,
+  "immed": true,
+  "newcap": true,
+  "noarg": true,
+  "undef": true,
+  "strict": true
+}

--- a/index.js
+++ b/index.js
@@ -68,26 +68,45 @@ function zetzer (trees, options) {
       }
     });
 
-    return process;
-
     function process (path) {
       return process_file(path).toString();
     }
 
+    return process;
+
     function find_closest_match (tree, name) {
       // Zetzer for pages passes "." which should be changed
-      if (tree === ".") return name;
+      if (tree === ".") {
+        return name;
+      }
+
+      var root = tree.root;
 
       var path = tree.paths.filter(function (path) {
-        return path.indexOf(name) === 0;
+        var cur = join_paths(root, path);
+
+        // If not a folder
+        if (!fs.lstatSync(cur).isDirectory()) {
+          if (path.indexOf(name) === 0) {
+            // If character after name is not a dot or slash
+            var end = path.replace(name, '');
+            var firstChar = end.charAt(0);
+            return firstChar === '.';
+          }
+        }
+        return false;
       })[0];
+
+      if (path === undefined) {
+        throw new Error('Couldn\'t find a matching file for', name);
+      }
 
       return join_paths(tree.root, path);
     }
   }
 
   function cleanup () {
-    quick_temp.remove(tmp, "path");
+    //quick_temp.remove(tmp, "path");
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -81,12 +81,17 @@ function zetzer (trees, options) {
       }
 
       var root = tree.root;
-
+      
       var path = tree.paths.filter(function (path) {
         var cur = join_paths(root, path);
 
         // If not a folder
         if (!fs.lstatSync(cur).isDirectory()) {
+          // If exact correct path
+          if (path === name) {
+            return true;
+          }
+
           if (path.indexOf(name) === 0) {
             // If character after name is not a dot or slash
             var end = path.replace(name, '');
@@ -96,9 +101,9 @@ function zetzer (trees, options) {
         }
         return false;
       })[0];
-
+      
       if (path === undefined) {
-        throw new Error('Couldn\'t find a matching file for', name);
+        throw new Error('Couldn\'t find a matching file for ' + name);
       }
 
       return join_paths(tree.root, path);

--- a/package.json
+++ b/package.json
@@ -12,6 +12,13 @@
   "bugs": {
     "url": "https://github.com/szywon/broccoli-zetzer/issues"
   },
+  "scripts": {
+    "hint": "jshint index.js",
+    "dev": "npm run watch",
+    "test": "mocha tests/",
+    "watch": "watchify **/*.js -o 'npm run hint && npm run test'"
+  },
+  "main": "index.js",
   "dependencies": {
     "zetzer": "^2.0.0",
     "underscore": "^1.6.0",
@@ -19,12 +26,16 @@
     "broccoli-dep-filter": "^0.3.0"
   },
   "devDependencies": {
-    "broccoli-cli": "*",
     "broccoli": "0.13",
-    "walk-sync": "0.1",
+    "broccoli-cli": "*",
+    "expect.js": "^0.3.1",
+    "grunt-zetzer": "^2.0.0",
+    "jshint": "^2.8.0",
     "mkdirp": "0.3",
+    "mocha": "^2.2.5",
     "quick-temp": "0.1",
-    "grunt-zetzer": "^2.0.0"
+    "walk-sync": "0.1",
+    "watchify": "^3.2.3"
   },
   "keywords": [
     "broccoli-plugin",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "underscore": "^1.6.0",
     "promise-map-series": "0.2",
     "mkdirp": "0.3",
-    "broccoli-dep-filter": "^0.3.0"
+    "broccoli-dep-filter": "^0.3.0",
+    "quick-temp": "0.1",
+    "walk-sync": "0.1"
   },
   "devDependencies": {
     "broccoli": "0.13",
@@ -33,8 +35,6 @@
     "grunt-zetzer": "^2.0.0",
     "jshint": "^2.8.0",
     "mocha": "^2.2.5",
-    "quick-temp": "0.1",
-    "walk-sync": "0.1",
     "watchify": "^3.2.3"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -2,15 +2,18 @@
   "name": "broccoli-zetzer",
   "description": "Broccoli plugin for Zetzer",
   "version": "2.0.0",
-  "homepage": "https://github.com/brainshave/zetzer",
-  "author": "Szymon Witamborski <simon@brainshave.com>",
+  "homepage": "https://github.com/raiseandfall/broccoli-zetzer",
+  "author": {
+    "name": "raiseandfall",
+    "url": "https://github.com/raiseandfall"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/szywon/broccoli-zetzer.git"
+    "url": "https://github.com/raiseandfall/broccoli-zetzer.git"
   },
   "bugs": {
-    "url": "https://github.com/szywon/broccoli-zetzer/issues"
+    "url": "https://github.com/raiseandfall/broccoli-zetzer/issues"
   },
   "scripts": {
     "hint": "jshint index.js",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "zetzer": "^2.0.0",
     "underscore": "^1.6.0",
     "promise-map-series": "0.2",
+    "mkdirp": "0.3",
     "broccoli-dep-filter": "^0.3.0"
   },
   "devDependencies": {
@@ -31,7 +32,6 @@
     "expect.js": "^0.3.1",
     "grunt-zetzer": "^2.0.0",
     "jshint": "^2.8.0",
-    "mkdirp": "0.3",
     "mocha": "^2.2.5",
     "quick-temp": "0.1",
     "walk-sync": "0.1",

--- a/tests/fixtures/pages-subcomponent/home.dot.html
+++ b/tests/fixtures/pages-subcomponent/home.dot.html
@@ -1,0 +1,7 @@
+{
+  "template": "main"
+}
+
+<h1>Bonjour le monde</h1>
+
+{{= it.include("component-sub") }}

--- a/tests/fixtures/pages/home.dot.html
+++ b/tests/fixtures/pages/home.dot.html
@@ -1,0 +1,7 @@
+{
+  "template": "main"
+}
+
+<h1>Bonjour le monde</h1>
+
+{{= it.include("component") }}

--- a/tests/fixtures/partials/component-sub.dot.html
+++ b/tests/fixtures/partials/component-sub.dot.html
@@ -1,0 +1,3 @@
+<h3>Component including sub-component</h3>
+
+{{= it.include("component/subcomponent") }}

--- a/tests/fixtures/partials/component.dot.html
+++ b/tests/fixtures/partials/component.dot.html
@@ -1,0 +1,1 @@
+<h3>Component</h3>

--- a/tests/fixtures/partials/component/subcomponent.dot.html
+++ b/tests/fixtures/partials/component/subcomponent.dot.html
@@ -1,0 +1,1 @@
+<h4>Sub-component</h4>

--- a/tests/fixtures/partials/footer.dot.html
+++ b/tests/fixtures/partials/footer.dot.html
@@ -1,0 +1,3 @@
+<footer>
+Footer
+</footer>

--- a/tests/fixtures/partials/header.dot.html
+++ b/tests/fixtures/partials/header.dot.html
@@ -1,0 +1,3 @@
+<header>
+Header
+</header>

--- a/tests/fixtures/templates/main.dot.html
+++ b/tests/fixtures/templates/main.dot.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+{{= it.include("header") }}
+{{= it.document }}
+{{= it.include("footer") }}
+</body>
+</html>

--- a/tests/mocks/home-subcomponent.html
+++ b/tests/mocks/home-subcomponent.html
@@ -1,0 +1,1 @@
+<html><body><header>Header</header><h1>Bonjour le monde</h1><h3>Component including sub-component</h3><h4>Sub-component</h4><footer>Footer</footer></body></html>

--- a/tests/mocks/home.html
+++ b/tests/mocks/home.html
@@ -1,0 +1,1 @@
+<html><body><header>Header</header><h1>Bonjour le monde</h1><h3>Component</h3><footer>Footer</footer></body></html>

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,0 +1,47 @@
+'use strict';
+
+var zetzer = require('../');
+var expect = require('expect.js');
+var broccoli = require('broccoli');
+var fs = require('fs');
+var builder;
+
+describe('broccoli zetzer', function() {
+  afterEach(function() {
+    if (builder) {
+      builder.cleanup();
+    }
+  });
+
+  it ('should generate HTML page with partial', function() {
+    var tree = zetzer({
+      pages: 'tests/fixtures/pages',
+      partials: 'tests/fixtures/partials',
+      templates: 'tests/fixtures/templates'
+    });
+
+    builder = new broccoli.Builder(tree);
+
+    return builder.build().then(function(dir) {
+      var actual = fs.readFileSync(dir.directory + '/home.dot.html', {encoding: 'utf8'});
+      var expected = fs.readFileSync('tests/mocks/home.html', {encoding: 'utf8'});
+      expect(actual).to.equal(expected);
+    });
+  });
+
+  it ('should generate HTML page with partial in sub-folder', function() {
+    var tree = zetzer({
+      pages: 'tests/fixtures/pages-subcomponent',
+      partials: 'tests/fixtures/partials',
+      templates: 'tests/fixtures/templates'
+    });
+
+    builder = new broccoli.Builder(tree);
+
+    return builder.build().then(function(dir) {
+      var actual = fs.readFileSync(dir.directory + '/home.dot.html', {encoding: 'utf8'});
+      var expected = fs.readFileSync('tests/mocks/home-subcomponent.html', {encoding: 'utf8'});
+      expect(actual).to.equal(expected);
+    });
+  });
+});


### PR DESCRIPTION
Hey there,

I improved the `find_closest_match` function.
I recently switched from stencil to zetzer on a project, and wasn't allowed to re-write the it.include() calls (after finding out the bug that I'm trying to fix here).

I realised that if you have the following in the templates folder : 

```
templates/component.dot.html
templates/component/component.dot.html
templates/component-sub.dot.html
```

And if you are including the following in a page : 

```
{{= it.include("component") }}
```

Then zetzer wouldn't be loading `templates/component.dot.html` as intended, but was trying to load the directory `templates/component/`, or `templates/component-sub.dot.html` if no folder.

I updated the find_closest_match function to fix it, and I also added some unit test.
